### PR TITLE
Função da busca de usuário agora não quebra quando você apaga o campo de busca após qualquer busca.

### DIFF
--- a/src/pages/ListUsersPage.jsx
+++ b/src/pages/ListUsersPage.jsx
@@ -57,8 +57,8 @@ export default function ListUsersPage() {
               </div>
             ) : (
               <div className="px-10 grid grid-cols-4 justify-items-center gap-5 mb-12">
-                {allUsersList?.map((user, index) => (
-                  <UserCard data={user} key={index} />
+                {allUsersList?.map((user) => (
+                  <UserCard data={user} key={user.id} />
                 ))}
               </div>
             )}


### PR DESCRIPTION
Anteriormente, ao apagar completamente a barra de pesquisa após qualquer busca, o primeiro usuário do resultado da busca seria duplicado e passaria por cima do primeiro usuário na exibição padrão de todos os usuários.

Exemplo:
Usuários - fulano, ciclano, deltrano

A página de busca com o campo vazio mostrava corretamente:
fulano - ciclano - deltrano

Porém ao pesquisar um usuário (ex: fulano):
ciclano

E depois apagar a busca:
ciclano - ciclano - deltrano